### PR TITLE
chore(token-map): add stratus testnet point & metadata (11155111)

### DIFF
--- a/sdk/constants/token-map/11155111/definitions/11155111-0xd295b8b73ca5277b5d4cbb91bedaca337cbd078e.ts
+++ b/sdk/constants/token-map/11155111/definitions/11155111-0xd295b8b73ca5277b5d4cbb91bedaca337cbd078e.ts
@@ -1,0 +1,14 @@
+import { defineToken } from "@/sdk/constants";
+
+export default defineToken({
+  id: "11155111-0xd295b8b73ca5277b5d4cbb91bedaca337cbd078e",
+  chain_id: 11155111,
+  contract_address: "0xd295b8b73ca5277b5d4cbb91bedaca337cbd078e",
+  name: "Test Stratus Point",
+  symbol: "TSTRAT",
+  image: "https://res.cloudinary.com/ds4pux6du/image/upload/v1745382106/static-assets/rpuiujhspdxihpziunic.png",
+  decimals: 18,
+  source: "external",
+  search_id: "none",
+  type: "point",
+});


### PR DESCRIPTION
### Changes

- Registered new token/point definition:
  - Address: `0xd295b8b73ca5277b5d4cbb91bedaca337cbd078e`
  - Network: Sepolia
  - Metadata includes: name, symbol, decimals, logoURI 
  - Type : Point

### Context
This update is part of the integration of stratus for internal testing purposes. The token metadata will be used in front-end token selection and analytics display.

---

Please review and merge if everything looks good. Let me know if adjustments are needed.
